### PR TITLE
Coordonnées GPS inutiles

### DIFF
--- a/Developpement Arduino/main/GPS_manager.h
+++ b/Developpement Arduino/main/GPS_manager.h
@@ -10,7 +10,6 @@ Released into the INSA domain.
 struct GPS_coordinates{
   float latitude;
   float longitude;
-  float altitude;
 };
 
 GPS_coordinates GPS_get_coordinates(void);


### PR DESCRIPTION
pas besoin de l'altitude. Fixes #2 
